### PR TITLE
FLK-1575 - Provide implementations for module 1 labs

### DIFF
--- a/common/src/main/java/org/apache/flink/training/exercises/common/datatypes/DriverFaresByHour.java
+++ b/common/src/main/java/org/apache/flink/training/exercises/common/datatypes/DriverFaresByHour.java
@@ -1,0 +1,33 @@
+package org.apache.flink.training.exercises.common.datatypes;
+
+public class DriverFaresByHour {
+
+    public long driverId;
+    public float totalFares;
+    public Long endWindow;
+
+    @SuppressWarnings("unused")
+    public DriverFaresByHour() {
+        // default constructor required for serialization
+    }
+
+    public DriverFaresByHour(long driverId, float totalFares) {
+        this(driverId, totalFares, null);
+    }
+
+    public DriverFaresByHour(long driverId, float totalFares, Long endWindow) {
+        this.driverId = driverId;
+        this.totalFares = totalFares;
+        this.endWindow = endWindow;
+    }
+
+    @Override
+    public String toString() {
+        return "DriverFaresByHour{" +
+                "driverId=" + driverId +
+                ", totalFares=" + totalFares +
+                ", endWindow=" + endWindow +
+                '}';
+    }
+
+}

--- a/long-ride-alerts/src/main/java/org/apache/flink/training/exercises/longrides/LongRidesExercise.java
+++ b/long-ride-alerts/src/main/java/org/apache/flink/training/exercises/longrides/LongRidesExercise.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.training.exercises.longrides;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.TimerService;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
@@ -30,7 +32,6 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide;
 import org.apache.flink.training.exercises.common.sources.TaxiRideGenerator;
-import org.apache.flink.training.exercises.common.utils.MissingSolutionException;
 import org.apache.flink.util.Collector;
 
 import java.time.Duration;
@@ -44,6 +45,9 @@ import java.time.Duration;
  * <p>You should eventually clear any state you create.
  */
 public class LongRidesExercise {
+
+    private static final long MAX_DURATION_MS = 2 * 3600 * 1000;
+
     private final SourceFunction<TaxiRide> source;
     private final SinkFunction<Long> sink;
 
@@ -95,20 +99,63 @@ public class LongRidesExercise {
         job.execute();
     }
 
-    @VisibleForTesting
     public static class AlertFunction extends KeyedProcessFunction<Long, TaxiRide, Long> {
 
+        // register the ride START or END event (whichever comes first)
+        // this implementation assumes that there are no event duplicates
+        // (we can have at maximum a START and an END event)
+        private ValueState<TaxiRide> registeredRide;
+
         @Override
-        public void open(Configuration config) throws Exception {
-            throw new MissingSolutionException();
+        public void open(Configuration config) {
+            registeredRide = getRuntimeContext()
+                    .getState(new ValueStateDescriptor<>("registeredEvent", TaxiRide.class));
         }
 
         @Override
-        public void processElement(TaxiRide ride, Context context, Collector<Long> out)
-                throws Exception {}
+        public void processElement(TaxiRide ride, Context ctx, Collector<Long> out) throws Exception {
 
-        @Override
+            TimerService timerService = ctx.timerService();
+            if (ride.getEventTimeMillis() < timerService.currentWatermark()) {
+                return; // ignore late event
+            }
+            if (ride.isStart) {
+                if (registeredRide.value() != null) { // if END event already registered
+                    if (isLongDuration(ride.getEventTimeMillis(), registeredRide.value().getEventTimeMillis())) {
+                        out.collect(ride.rideId);
+                        registeredRide.clear();
+                    }
+                } else { // if no END event registered yet, register START event and timer
+                    registeredRide.update(ride);
+                    timerService.registerEventTimeTimer(ride.getEventTimeMillis() + MAX_DURATION_MS);
+                }
+            } else {
+                if (registeredRide.value() != null) { // START event already registered
+                    if (isLongDuration(registeredRide.value().getEventTimeMillis(), ride.getEventTimeMillis())) {
+                        // if we have a long ride but timer not launched yet (maybe because of a time race condition)
+                        out.collect(ride.rideId);
+                    }
+                    timerService.deleteEventTimeTimer(registeredRide.value().getEventTimeMillis() + MAX_DURATION_MS);
+                    registeredRide.clear();
+                } else {
+                    // if END event comes before the start event, we don't set a timer, since it will be
+                    // logically strange (time should go forward); in this case, long ride detection will be done
+                    // through a regular check
+                    registeredRide.update(ride);
+                }
+            }
+        }
+
         public void onTimer(long timestamp, OnTimerContext context, Collector<Long> out)
-                throws Exception {}
+                throws Exception {
+            out.collect(registeredRide.value().rideId);
+            registeredRide.clear();
+        }
+
+        private boolean isLongDuration(long startTimestamp, long endTimestamp) {
+            return endTimestamp - startTimestamp > MAX_DURATION_MS;
+        }
+
     }
+
 }

--- a/ride-cleansing/src/main/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingExercise.java
+++ b/ride-cleansing/src/main/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingExercise.java
@@ -26,7 +26,7 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide;
 import org.apache.flink.training.exercises.common.sources.TaxiRideGenerator;
-import org.apache.flink.training.exercises.common.utils.MissingSolutionException;
+import org.apache.flink.training.exercises.common.utils.GeoUtils;
 
 /**
  * The Ride Cleansing exercise from the Flink training.
@@ -79,8 +79,9 @@ public class RideCleansingExercise {
     /** Keep only those rides and both start and end in NYC. */
     public static class NYCFilter implements FilterFunction<TaxiRide> {
         @Override
-        public boolean filter(TaxiRide taxiRide) throws Exception {
-            throw new MissingSolutionException();
+        public boolean filter(TaxiRide taxiRide) {
+            return GeoUtils.isInNYC(taxiRide.startLon, taxiRide.startLat) &&
+                    GeoUtils.isInNYC(taxiRide.endLon, taxiRide.endLat);
         }
     }
 }

--- a/rides-and-fares/src/main/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresExercise.java
+++ b/rides-and-fares/src/main/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresExercise.java
@@ -102,8 +102,8 @@ public class RidesAndFaresExercise {
     public static class EnrichmentFunction
             extends RichCoFlatMapFunction<TaxiRide, TaxiFare, RideAndFare> {
 
-        private ValueState<TaxiRide> rideState;
-        private ValueState<TaxiFare> fareState;
+        private transient ValueState<TaxiRide> rideState;
+        private transient ValueState<TaxiFare> fareState;
 
         @Override
         public void open(Configuration config) {

--- a/rides-and-fares/src/main/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresExercise.java
+++ b/rides-and-fares/src/main/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresExercise.java
@@ -19,6 +19,8 @@
 package org.apache.flink.training.exercises.ridesandfares;
 
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -31,7 +33,6 @@ import org.apache.flink.training.exercises.common.datatypes.TaxiFare;
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide;
 import org.apache.flink.training.exercises.common.sources.TaxiFareGenerator;
 import org.apache.flink.training.exercises.common.sources.TaxiRideGenerator;
-import org.apache.flink.training.exercises.common.utils.MissingSolutionException;
 import org.apache.flink.util.Collector;
 
 /**
@@ -45,7 +46,9 @@ public class RidesAndFaresExercise {
     private final SourceFunction<TaxiFare> fareSource;
     private final SinkFunction<RideAndFare> sink;
 
-    /** Creates a job using the sources and sink provided. */
+    /**
+     * Creates a job using the sources and sink provided.
+     */
     public RidesAndFaresExercise(
             SourceFunction<TaxiRide> rideSource,
             SourceFunction<TaxiFare> fareSource,
@@ -59,8 +62,8 @@ public class RidesAndFaresExercise {
     /**
      * Creates and executes the pipeline using the StreamExecutionEnvironment provided.
      *
-     * @throws Exception which occurs during job execution.
      * @return {JobExecutionResult}
+     * @throws Exception which occurs during job execution.
      */
     public JobExecutionResult execute() throws Exception {
 
@@ -99,19 +102,35 @@ public class RidesAndFaresExercise {
     public static class EnrichmentFunction
             extends RichCoFlatMapFunction<TaxiRide, TaxiFare, RideAndFare> {
 
+        private ValueState<TaxiRide> rideState;
+        private ValueState<TaxiFare> fareState;
+
         @Override
-        public void open(Configuration config) throws Exception {
-            throw new MissingSolutionException();
+        public void open(Configuration config) {
+            rideState = getRuntimeContext()
+                    .getState(new ValueStateDescriptor<>("taxiRide", TaxiRide.class));
+            fareState = getRuntimeContext()
+                    .getState(new ValueStateDescriptor<>("taxiFare", TaxiFare.class));
         }
 
         @Override
         public void flatMap1(TaxiRide ride, Collector<RideAndFare> out) throws Exception {
-            throw new MissingSolutionException();
+            if (fareState.value() != null) {
+                out.collect(new RideAndFare(ride, fareState.value()));
+                fareState.clear();
+            } else {
+                rideState.update(ride);
+            }
         }
 
         @Override
         public void flatMap2(TaxiFare fare, Collector<RideAndFare> out) throws Exception {
-            throw new MissingSolutionException();
+            if (rideState.value() != null) {
+                out.collect(new RideAndFare(rideState.value(), fare));
+                rideState.clear();
+            } else {
+                fareState.update(fare);
+            }
         }
     }
 }


### PR DESCRIPTION
Implementations for the 4 labs required for Flink Training - Module 1

1. Ride Cleansing
- basic implementation testing the "filter" transformation

2. Rides and Fares
- implementation connecting 2 streams (for TaxiFare and TaxiRide) into one single stream of "RideAndFare"
- uses 2 value states to store rides and fares

3. Hourly tips
- outputs the driver with the largest sum of tips per hour
- uses keyed windows and a global window
- combines a reduce and a process window function to reduce state storage for the process window function
- for clarity, created a POJO class to store driver fares per hour 

4. Long rides
- outputs the rides longer than a maximum duration time (2 hours)
- uses a value state to register the first occurred ride (START or END event) and a timer to detect long rides
when the START event occurs first

Observation: all tests are passing
